### PR TITLE
chapter 12 - Reset Pasword

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -26,7 +26,7 @@ class AccountActivationsController < ApplicationController
   end
 
   def check_activation
-    return unless @user.activated? && !@user.authenticate?(:activation, params[:id])
+    return if !@user.activated? || @user.authenticate?(:activation, params[:id])
 
     flash[:danger] = t("layouts.messages.invalid_activation_link")
     redirect_to root_url

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# PasswordResetsController
+class PasswordResetsController < ApplicationController
+  before_action :load_user, :valid_user, :check_expiration, only: %i(create edit update)
+  before_action :check_password_presence, only: :update
+
+  def new; end
+
+  def create
+    if @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = t("users.mailer.sent_password_reset")
+      redirect_to root_url
+    else
+      flash.now[:danger] = t("users.mailer.password_reset_failed")
+      render :new
+    end
+  end
+
+  def update
+    if @user.update(user_params)
+      log_in @user
+      @user.update_columns(reset_digest: nil)
+      flash[:success] = t("users.mailer.password_reset_success")
+      redirect_to @user
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  private
+
+  def user_params
+    params.require(:user).permit :password, :password_confirmation
+  end
+
+  def load_user
+    @user = User.find_by(email: params.dig(:password_reset, :email)&.downcase || params[:email])
+    return if @user
+
+    flash[:danger] = t("layouts.messages.user_not_found")
+    redirect_to root_url
+  end
+
+  def valid_user
+    return if @user.activated
+
+    flash[:danger] = t("users.mailer.not_activated")
+    redirect_to root_url
+  end
+
+  def check_expiration
+    return unless @user.password_reset_expired?
+
+    flash[:danger] = t("users.mailer.password_reset_expired")
+    redirect_to new_password_reset_url
+  end
+
+  def check_password_presence
+    return if user_params[:password].present?
+
+    @user.errors.add(:password, :blank)
+    render :edit, status: :unprocessable_entity
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -7,8 +7,8 @@ class UserMailer < ApplicationMailer
     mail to: user.email, subject: t("users.mailer.activation")
   end
 
-  def password_reset
-    @greeting = t("users.mailer.activation")
-    mail(to: "to@example.org")
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: t("users.mailer.password_reset")
   end
 end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,15 @@
+<% provide(:title, t("users.mailer.password_reset")) %>
+<h1><%= t("users.mailer.password_reset") %></h1>
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@user, url: password_reset_path(params[:id])) do |f| %>
+      <%= render "shared/error_messages" %>
+      <%= hidden_field_tag :email, @user.email %>
+      <%= f.label :password %>
+      <%= f.password_field :password, class: "form-control" %>
+      <%= f.label :password_confirmation, t("users.new.confirmation") %>
+      <%= f.password_field :password_confirmation, class: "form-control" %>
+      <%= f.submit t("users.edit.update_password"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,11 @@
+<% provide :title, t("layouts.header.forgot_password") %>
+<h1><%= t("layouts.header.forgot_password") %></h1>
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for :password_reset, url: password_resets_path do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: "form-control" %>
+      <%= f.submit t("users.new.submit"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -6,6 +6,7 @@
       <%= f.label :email %>
       <%= f.email_field :email, class: "form-control" %>
       <%= f.label :password %>
+        <%= link_to t("layouts.messages.forgot_password"), new_password_reset_path %>
       <%= f.password_field :password, class: "form-control" %>
       <%= f.label :remember_me, class: "checkbox inline" do %>
         <%= f.check_box :remember_me %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t("users.mailer.password_reset") %></h1>
+<p><%= t("users.mailer.password_reset_instruction1") %></p>
+<%= link_to t("users.mailer.password_reset"), edit_password_reset_url(id: @user.reset_token, email: @user.email) %>
+<p><%= t("users.mailer.password_reset_instruction2") %></p>
+<p><%= t("users.mailer.password_reset_instruction3") %></p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,4 @@
+<%= t("users.mailer.password_reset_instruction1") %>
+<%= edit_password_reset_url id: @user.reset_token, email: @user.email %>
+<%= t("users.mailer.password_reset_instruction2") %>
+<%= t("users.mailer.password_reset_instruction3") %>

--- a/config/locales/activerecord/en.yml
+++ b/config/locales/activerecord/en.yml
@@ -22,3 +22,7 @@ en:
             birthday:
               blank: "can't be blank"
               birthday_within_last_100_years: "must be within the last 100 years"
+            password:
+              blank: "can't be blank"
+              too_short: "is too short (minimum is %{count} characters)"
+              too_long: "is too long (maximum is %{count} characters)"

--- a/config/locales/activerecord/vi.yml
+++ b/config/locales/activerecord/vi.yml
@@ -22,3 +22,7 @@ vi:
             birthday:
               blank: "Không thể bỏ trống"
               birthday_within_last_100_years: "Phải bé hơn 100 tuổi"
+            password:
+              blank: "Không thể bỏ trống"
+              too_short: "Quá ngắn (tối thiểu %{count} kí tự)"
+              too_long: "Quá dài (tối đa %{count} kí tự)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
       account: "Account"
       edit_user: "Edit User"
       user_mailer: "User Mailer"
+      forgot_password: "Forgot Password"
     messages:
       success: "Successfully!"
       error: "Fail, please try again!"
@@ -21,6 +22,7 @@ en:
       please_log_in: "Please log in!"
       not_authorized: "Not authorized!"
       deleted_success: "Deleted successfully!"
+      forgot_password: "(forgot password)"
   helpers:
     page_title: "Ruby on Rails Tutorials Sample App"
   static_pages:
@@ -36,10 +38,12 @@ en:
       sign_up: "Sign Up"
       create_my_account: "Create My Account"
       confirmation: "Confirmation"
+      submit: "Submit"
     edit:
       update_profile: "Update your profile"
       save_changes: "Save Changes"
       change: "Change"
+      update_password: "Update Password"
     index:
       all_users: "All Users"
       user_not_found: "User not found!"
@@ -55,3 +59,11 @@ en:
       activated: "Activated"
       invalid_activation_link: "Invalid activation link"
       not_activated: "Account not activated. Check your email for the activation link."
+      sent_password_reset: "Email sent with password reset instructions"
+      password_reset: "Reset Password"
+      password_reset_instruction1: "To reset your password click the link below:"
+      password_reset_instruction2: "This link will expire in two hours."
+      password_reset_instruction3: "If you did not request your password to be reset, please ignore this email and your password will stay as it is."
+      password_reset_expired: "Password reset has expired"
+      password_reset_success: "Password has been reset"
+      password_reset_failed: "Password reset failed"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -11,6 +11,7 @@ vi:
       account: "Tài khoản"
       edit_user: "Chỉnh sửa thông tin"
       user_mailer: "Thư người dùng"
+      forgot_password: "Quên mật khẩu"
     messages:
       success: "Thành công!"
       error: "Thất bại, vui lòng thử lại!"
@@ -21,6 +22,7 @@ vi:
       please_log_in: "Vui lòng đăng nhập!"
       not_authorized: "Không được phép!"
       deleted_success: "Xóa thành công!"
+      forgot_password: "(quên mật khẩu)"
   helpers:
     page_title: "Ứng dụng Mẫu Ruby on Rails"
   static_pages:
@@ -36,10 +38,12 @@ vi:
       sign_up: "Đăng ký"
       create_my_account: "Tạo tài khoản"
       confirmation: "Xác nhận"
+      submit: "Gửi"
     edit:
       update_profile: "Cập nhật thông tin cá nhân"
       save_changes: "Lưu thay đổi"
       change: "Thay đổi"
+      update_password: "Cập nhật mật khẩu"
     index:
       all_users: "Tất cả người dùng"
       user_not_found: "Không tìm thấy người dùng!"
@@ -54,4 +58,12 @@ vi:
       information: "Vui lòng kiểm tra email của bạn để kích hoạt tài khoản."
       activated: "Đã kích hoạt"
       invalid_activation_link: "Liên kết kích hoạt không hợp lệ"
-      not_activated: "Tài khoản chưa được kích hoạt. Vui lòng kiểm tra email của bạn để lấy liên kết kích hoạt."
+      not_activated: "Tài khoản chưa được kích hoạt. Kiểm tra email của bạn để lấy liên kết kích hoạt."
+      sent_password_reset: "Email đã được gửi với hướng dẫn đặt lại mật khẩu"
+      password_reset: "Đặt lại mật khẩu"
+      password_reset_instruction1: "Để đặt lại mật khẩu, hãy nhấp vào liên kết bên dưới:"
+      password_reset_instruction2: "Link sẽ hết hạn sau 2 giờ."
+      password_reset_instruction3: "Nếu bạn không yêu cầu đặt lại mật khẩu, vui lòng bỏ qua email này."
+      password_reset_expired: "Liên kết đặt lại mật khẩu đã hết hạn"
+      password_reset_success: "Mật khẩu đã được đặt lại"
+      password_reset_failed: "Đặt lại mật khẩu thất bại"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
   post "/signup", to: "users#create"
   resources :users
   resources :account_activations, only: :edit
+  resources :password_resets, only: %i(new create edit update)
 end

--- a/db/migrate/20240313112351_add_reset_to_users.rb
+++ b/db/migrate/20240313112351_add_reset_to_users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# AddResetToUsers class
+class AddResetToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_313_001_616) do
+ActiveRecord::Schema[7.1].define(version: 20_240_313_112_351) do
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -26,5 +26,7 @@ ActiveRecord::Schema[7.1].define(version: 20_240_313_001_616) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
   end
 end


### PR DESCRIPTION
- Action Mailer hỗ trợ cả plain-text and HTML mail.
- Việc đặt lại mật khẩu sử dụng mã thông báo được tạo để tạo một URL duy nhất để đặt lại mật khẩu giúp tăng tính bảo mật khi người dùng muốn thay đổi mật khẩu.
- Tương tự như các action và view thông thường, các biến instance được định nghĩa trong các hành động của mailer cũng có sẵn trong các view của mailer.
![Screenshot from 2024-03-15 14-05-37](https://github.com/thanhhung-131/sample_app/assets/83440136/afcd3ddb-aa9f-4b3d-a55d-fab8c861cb68)
